### PR TITLE
Fix crash when throwable cause is already initialized

### DIFF
--- a/traceur/src/main/java/com/tspoon/traceur/TraceurException.java
+++ b/traceur/src/main/java/com/tspoon/traceur/TraceurException.java
@@ -50,7 +50,12 @@ public class TraceurException extends RuntimeException {
             }
         }
 
-        t.initCause(this);
+        try {
+            t.initCause(this);
+        } catch(Exception e) {
+            // initCause is only designed to be called once and if it's already been called, there's
+            // not much we can do about it.
+        }
 
         return throwable;
     }


### PR DESCRIPTION
## Issue
When trying to append a TraceurException to a throwable which has already had it's cause initialised, an exception is thrown.
See https://github.com/T-Spoon/Traceur/issues/7

## Resolution
In this case, theres not much we can do to resolve the issue because Throwable#initCause is not designed to be called twice. So the fix in this PR uses the same logic as the RxJava2Extensions project by catching any exception and continuing.
See https://github.com/akarnokd/RxJava2Extensions/blob/2ec72c9a317da02717d207f876ca5ba43768d802/src/main/java/hu/akarnokd/rxjava2/debug/RxJavaAssemblyException.java#L129