### PR TITLE
Upgrade to RxJava 2.2.1, fixes due to internal changes

### DIFF
--- a/traceur/build.gradle
+++ b/traceur/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
-    compile 'io.reactivex.rxjava2:rxjava:2.0.7'
+    compile 'io.reactivex.rxjava2:rxjava:2.2.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:3.6.2'

--- a/traceur/src/main/java/com/tspoon/traceur/FlowableOnAssembly.java
+++ b/traceur/src/main/java/com/tspoon/traceur/FlowableOnAssembly.java
@@ -61,12 +61,12 @@ final class FlowableOnAssembly<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            downstream.onNext(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(assembled.appendTo(t));
+            downstream.onError(assembled.appendTo(t));
         }
 
         @Override
@@ -98,17 +98,17 @@ final class FlowableOnAssembly<T> extends Flowable<T> {
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            downstream.onNext(t);
         }
 
         @Override
         public boolean tryOnNext(T t) {
-            return actual.tryOnNext(t);
+            return downstream.tryOnNext(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(assembled.appendTo(t));
+            downstream.onError(assembled.appendTo(t));
         }
 
         @Override

--- a/traceur/src/main/java/com/tspoon/traceur/ObservableOnAssembly.java
+++ b/traceur/src/main/java/com/tspoon/traceur/ObservableOnAssembly.java
@@ -54,17 +54,17 @@ final class ObservableOnAssembly<T> extends Observable<T> {
 
         @Override
         public void onNext(T t) {
-            actual.onNext(t);
+            downstream.onNext(t);
         }
 
         @Override
         public void onError(Throwable t) {
-            actual.onError(assembled.appendTo(t));
+            downstream.onError(assembled.appendTo(t));
         }
 
         @Override
         public int requestFusion(int mode) {
-            QueueDisposable<T> qs = this.qs;
+            QueueDisposable<T> qs = this.qd;
             if (qs != null) {
                 int m = qs.requestFusion(mode);
                 sourceMode = m;
@@ -75,7 +75,7 @@ final class ObservableOnAssembly<T> extends Observable<T> {
 
         @Override
         public T poll() throws Exception {
-            return qs.poll();
+            return qd.poll();
         }
     }
 }


### PR DESCRIPTION
This PR upgrades the library to RxJava 2.2.1 and updates the code that depended on internal components, which have been changed in RxJava 2.2.1, making the release version of this library incompatible with 2.2.1.